### PR TITLE
Stop Returning Pointer for DB GenerateCredentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.5] - 2022-05-13
+### Changed
+- DB GenerateCredentials to return Credentials struct instead of a pointer
+
 ## [0.0.4] - 2022-05-13
 ### Added
 - Lease information to Database credentials so that you know when the secret expires

--- a/db/db.go
+++ b/db/db.go
@@ -34,7 +34,7 @@ type Lease struct {
 const httpPathDBCredentials = "/v1/database/creds/"
 
 // GenerateCredentials generates a new set of dynamic credentials based on the role.
-func (db *Client) GenerateCredentials(ctx context.Context, role string) (*Credentials, error) {
+func (db *Client) GenerateCredentials(ctx context.Context, role string) (Credentials, error) {
 	type credentialsResponse struct {
 		Username string `json:"username"`
 		Password string `json:"password"`
@@ -49,17 +49,17 @@ func (db *Client) GenerateCredentials(ctx context.Context, role string) (*Creden
 
 	res, err := db.API.Read(ctx, httpPathDBCredentials+role, db.TokenManager.GetToken().Value)
 	if err != nil {
-		return nil, fmt.Errorf("failed to perform database credentials generation request: %w", err)
+		return Credentials{}, fmt.Errorf("failed to perform database credentials generation request: %w", err)
 	}
 
 	if res.StatusCode != 200 {
-		return nil, fmt.Errorf("received invalid status code %d for http request", res.StatusCode)
+		return Credentials{}, fmt.Errorf("received invalid status code %d for http request", res.StatusCode)
 	}
 
 	resBody := new(credentialsResponseWrapper)
 	err = res.JSON(resBody)
 	if err != nil {
-		return nil, err
+		return Credentials{}, err
 	}
 
 	credentials := Credentials{
@@ -72,5 +72,5 @@ func (db *Client) GenerateCredentials(ctx context.Context, role string) (*Creden
 		},
 	}
 
-	return &credentials, nil
+	return credentials, nil
 }


### PR DESCRIPTION
Updated DB GenerateCredentials to return a struct instead of a pointer to a struct. In general, we want to make the zero value useful and only rely on pointers when strictly necessary.